### PR TITLE
Export Catalog Specifications

### DIFF
--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,5 +1,5 @@
 import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
-import { Brand, Category, Specification, SpecificationValue } from '../typings/typings'
+import { Brand, Category, ProductAndSkuByCategoryResult, Specification, SpecificationValue, ProductSpecification, SpecificationFields } from '../typings/typings'
 
 /** Catalog API
  * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
@@ -35,5 +35,14 @@ export class Catalog extends ExternalClient {
 
   public getSpecificationValues = (id: number): Promise<SpecificationValue[]> =>
     this.http.get(`pub/specification/fieldvalue/${id}`)
+
+  public getSpecificationFields = (id: number): Promise<SpecificationFields> =>
+    this.http.get(`pub/specification/fieldGet/${id}`)
+
+  public getProductAndSkuByCategory = (categoryId: number, from: number, to: number): Promise<ProductAndSkuByCategoryResult> =>
+    this.http.get(`pvt/products/GetProductAndSkuIds?categoryId=${categoryId}&_from=${from}&_to=${to}`)
+
+  public getProductSpecification = (id: string): Promise<ProductSpecification[]> =>
+    this.http.get(`pvt/products/${id}/specification`)
 
 }

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,4 +1,5 @@
 import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
+import { Brand, Category, Specification, SpecificationValue } from '../typings/typings'
 
 /** Catalog API
  * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
@@ -20,9 +21,19 @@ export class Catalog extends ExternalClient {
     )
   }
 
-  public exportBrands = (): Promise<Array<Record<string, string>>> =>
+  public exportBrands = (): Promise<Brand[]> =>
     this.http.get('pvt/brand/list')
 
-  public exportCategories = (): Promise<Array<Record<string, string>>> =>
+  public exportCategories = (): Promise<Category[]> =>
     this.http.get('pub/category/listAll')
+
+  public getSpecificationsByCategory = (id: number): Promise<Specification[]> =>
+    this.http.get(`pub/specification/field/listByCategoryId/${id}`)
+
+  public getSpecificationsTreeByCategory = (id: number): Promise<Specification[]> =>
+    this.http.get(`pub/specification/field/listTreeByCategoryId/${id}`)
+
+  public getSpecificationValues = (id: number): Promise<SpecificationValue[]> =>
+    this.http.get(`pub/specification/fieldvalue/${id}`)
+
 }

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,5 +1,5 @@
 import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
-import { Brand, Category, ProductAndSkuByCategoryResult, Specification, SpecificationValue, ProductSpecification, SpecificationFields } from '../typings/typings'
+import { Brand, Category, ProductAndSkuByCategoryResult, ProductSpecification, Specification, SpecificationFields, SpecificationValue } from '../typings/typings'
 
 /** Catalog API
  * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,6 +1,6 @@
 import { IOClients } from '@vtex/api'
 import { Admin } from './admin'
-import { Catalog } from './catalog';
+import { Catalog } from './catalog'
 
 export class Clients extends IOClients {
   get admin(): Admin {

--- a/node/handlers/categorySpecs.ts
+++ b/node/handlers/categorySpecs.ts
@@ -1,8 +1,0 @@
-import { getCategorySpecsXLXS } from '../resources/categorySpecs'
-
-export default async function categorySpecsHandler(ctx: Context) {
-  ctx.status = 200
-  ctx.body = await getCategorySpecsXLXS(ctx)
-  ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-  ctx.set('cache-control', 'no-cache')
-}

--- a/node/handlers/categorySpecs.ts
+++ b/node/handlers/categorySpecs.ts
@@ -1,8 +1,8 @@
-import { getCategoryXLSX } from '../resources/category'
+import { getCategorySpecsXLXS } from '../resources/categorySpecs'
 
 export default async function categoriesHandler(ctx: Context) {
   ctx.status = 200
-  ctx.body = await getCategoryXLSX(ctx)
+  ctx.body = await getCategorySpecsXLXS(ctx)
   ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
   ctx.set('cache-control', 'no-cache')
 }

--- a/node/handlers/categorySpecs.ts
+++ b/node/handlers/categorySpecs.ts
@@ -1,6 +1,6 @@
 import { getCategorySpecsXLXS } from '../resources/categorySpecs'
 
-export default async function categoriesHandler(ctx: Context) {
+export default async function categorySpecsHandler(ctx: Context) {
   ctx.status = 200
   ctx.body = await getCategorySpecsXLXS(ctx)
   ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')

--- a/node/handlers/index.ts
+++ b/node/handlers/index.ts
@@ -1,9 +1,12 @@
 import brands from './brands'
 import categories from './categories'
 import categorySpecs from './categorySpecs'
+import productSpecs from './productSpecs'
+
 
 export default {
   brands,
   categories,
   categorySpecs,
+  productSpecs,
 }

--- a/node/handlers/index.ts
+++ b/node/handlers/index.ts
@@ -3,7 +3,6 @@ import categories from './categories'
 import specifications from './specifications'
 import textSpecificationstValues from './specificationsTextValues'
 
-
 export default {
   brands,
   categories,

--- a/node/handlers/index.ts
+++ b/node/handlers/index.ts
@@ -1,12 +1,12 @@
 import brands from './brands'
 import categories from './categories'
-import categorySpecs from './categorySpecs'
-import productSpecs from './productSpecs'
+import specifications from './specifications'
+import textSpecificationstValues from './specificationsTextValues'
 
 
 export default {
   brands,
   categories,
-  categorySpecs,
-  productSpecs,
+  specifications,
+  textSpecificationstValues,
 }

--- a/node/handlers/index.ts
+++ b/node/handlers/index.ts
@@ -1,7 +1,9 @@
 import brands from './brands'
 import categories from './categories'
+import categorySpecs from './categorySpecs'
 
 export default {
   brands,
   categories,
+  categorySpecs,
 }

--- a/node/handlers/productSpecs.ts
+++ b/node/handlers/productSpecs.ts
@@ -1,0 +1,8 @@
+import { getProductsSpecifications } from '../resources/productSpecs'
+
+export default async function productSpecsHandler(ctx: Context) {
+  ctx.status = 200
+  ctx.body = await getProductsSpecifications(ctx)
+  ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  ctx.set('cache-control', 'no-cache')
+}

--- a/node/handlers/productSpecs.ts
+++ b/node/handlers/productSpecs.ts
@@ -1,8 +1,0 @@
-import { getProductsSpecifications } from '../resources/productSpecs'
-
-export default async function productSpecsHandler(ctx: Context) {
-  ctx.status = 200
-  ctx.body = await getProductsSpecifications(ctx)
-  ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-  ctx.set('cache-control', 'no-cache')
-}

--- a/node/handlers/specifications.ts
+++ b/node/handlers/specifications.ts
@@ -1,0 +1,8 @@
+import { getSpecificationsXLXS } from '../resources/categorySpecs'
+
+export default async function getSpecificationsHandler(ctx: Context) {
+  ctx.status = 200
+  ctx.body = await getSpecificationsXLXS(ctx)
+  ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  ctx.set('cache-control', 'no-cache')
+}

--- a/node/handlers/specificationsTextValues.ts
+++ b/node/handlers/specificationsTextValues.ts
@@ -1,0 +1,8 @@
+import { getTextSpecificationstValues } from '../resources/productSpecs'
+
+export default async function textSpecificationstValuesHandler(ctx: Context) {
+  ctx.status = 200
+  ctx.body = await getTextSpecificationstValues(ctx)
+  ctx.set('content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  ctx.set('cache-control', 'no-cache')
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -7,6 +7,10 @@ import exportProductCatalog from './resolvers/exportProductCatalog'
 const TRANSLATION_CONCURRENCY = 5
 const TRANSLATION_RETRIES = 3
 
+const CATALOG_RETRIES = 3
+const CATALOG_CONCURRENCY = 50
+const CATALOG_TIMEOUT_MS = 5000
+
 const SMALL_TIMEOUT_MS = 500
 const HUGE_TIMEOUT_MS = 5000
 
@@ -19,6 +23,11 @@ export default new Service<Clients>({
     implementation: Clients,
     options: {
       admin: { timeout: HUGE_TIMEOUT_MS },
+      catalog: {
+        concurrency: CATALOG_CONCURRENCY,
+        retries: CATALOG_RETRIES,
+        timeout: CATALOG_TIMEOUT_MS,
+      },
       messagesGraphQL: {
         concurrency: TRANSLATION_CONCURRENCY,
         retries: TRANSLATION_RETRIES,

--- a/node/resources/brand.ts
+++ b/node/resources/brand.ts
@@ -1,17 +1,8 @@
-import { pick } from 'ramda'
+import { BrandTranslatables } from '../typings/typings'
 import { createXLSX, jsonToXLSXFields } from './xlsx'
 
-enum BrandTranslatableField {
-  metaTagDescription = 'metaTagDescription',
-  name = 'name',
-  title = 'title',
-}
-
-const getBrandTranslatableFields = pick(Object.values(BrandTranslatableField))
-
-type BrandTranslatables = Record<BrandTranslatableField, string>
-
-const jsonToXLSXField: BrandTranslatables = {
+const jsonToXLSXMap: Record<keyof BrandTranslatables, string> = {
+  id: '_BrandId',
   metaTagDescription: '_MetaTagDescription',
   name: '_Name',
   title: '_Title',
@@ -20,7 +11,6 @@ const jsonToXLSXField: BrandTranslatables = {
 export async function getBrandXLSX(ctx: Context) {
   const { clients: { catalog } } = ctx
   const brands = await catalog.exportBrands()
-  const brandsTranslatableFields = brands.map(getBrandTranslatableFields)
-  const brandXLSX = brandsTranslatableFields.map(brand => jsonToXLSXFields(brand, jsonToXLSXField))
-  return createXLSX(brandXLSX, 'Brands')
+
+  return createXLSX({ Brands: brands.map(brand => jsonToXLSXFields(brand, jsonToXLSXMap)) })
 }

--- a/node/resources/category.ts
+++ b/node/resources/category.ts
@@ -1,26 +1,23 @@
 import { pick } from 'ramda'
+import { CategoryTranslatables } from '../typings/typings'
 import { createXLSX, jsonToXLSXFields } from './xlsx'
 
-enum CategoriesTranslatableField {
-  metaTagDescription = 'MetaTagDescription',
-  name = 'name',
-  title = 'Title',
-}
 
-const getBrandTranslatableFields = pick(Object.values(CategoriesTranslatableField))
-
-type CategoriesTranslatables = Record<CategoriesTranslatableField, string>
-
-const jsonToXLSXField: CategoriesTranslatables = {
+const jsonToXLSXMap: Record<keyof CategoryTranslatables, string> = {
   MetaTagDescription: '_MetaTagDescription',
   Title: '_Title',
+  id: '_CategoryId',
   name: '_Name',
 }
+
+const getBrandTranslatableFields = pick(Object.keys(jsonToXLSXMap) as Array<
+  keyof CategoryTranslatables
+>)
 
 export async function getCategoryXLSX(ctx: Context) {
   const { clients: { catalog } } = ctx
   const categories = await catalog.exportCategories()
   const categoriesTranslatableFields = categories.map(getBrandTranslatableFields)
-  const categoriesXLSX = categoriesTranslatableFields.map(category => jsonToXLSXFields(category, jsonToXLSXField))
-  return createXLSX(categoriesXLSX, 'Categories')
+  const categoriesXLSX = categoriesTranslatableFields.map(category => jsonToXLSXFields(category, jsonToXLSXMap))
+  return createXLSX({ Categories: categoriesXLSX })
 }

--- a/node/resources/categorySpecs.ts
+++ b/node/resources/categorySpecs.ts
@@ -12,7 +12,7 @@ const valueToXLSXMap: Record<keyof SpecificationValueTranslatables, string> = {
   Value: '_Value',
 }
 
-export function getCategoriesSpecifications(
+export function getSpecifications(
   categories: Category[],
   { clients: { catalog } }: Context
 ): Promise<Specification[]> {
@@ -24,10 +24,10 @@ export function getCategoriesSpecifications(
     .then(uniqBy(({ FieldId }) => FieldId))
 }
 
-export async function getCategorySpecsXLXS(ctx: Context) {
+export async function getSpecificationsXLXS(ctx: Context) {
   const { clients: { catalog } } = ctx
   const categories = await catalog.exportCategories()
-  const specifications = await getCategoriesSpecifications(categories, ctx)
+  const specifications = await getSpecifications(categories, ctx)
 
   const specificationValues = await Promise.all(
     specifications.map(({ FieldId }) => catalog.getSpecificationValues(FieldId))

--- a/node/resources/categorySpecs.ts
+++ b/node/resources/categorySpecs.ts
@@ -1,0 +1,43 @@
+import { uniqBy, unnest } from 'ramda'
+import { SpecificationTranslatables, SpecificationValueTranslatables } from '../typings/typings'
+import { createXLSX, jsonToXLSXFields } from './xlsx'
+
+const specificationToXLSXMap: Record<keyof SpecificationTranslatables, string> = {
+  FieldId: '_FieldId',
+  Name: '_Name',
+}
+
+const valueToXLSXMap: Record<keyof SpecificationValueTranslatables, string> = {
+  FieldValueId: '_ValueId',
+  Value: '_Value',
+}
+
+export async function getCategorySpecsXLXS(ctx: Context) {
+  const { clients: { catalog } } = ctx
+  const categories = await catalog.exportCategories()
+
+  const specifications = await Promise.all([
+    catalog.getSpecificationsTreeByCategory(categories[0].id),
+    ...categories.map(({ id }) => catalog.getSpecificationsByCategory(id)),
+  ])
+    .then(specificationsByCategory => unnest(specificationsByCategory))
+    .then(uniqBy(({ FieldId }) => FieldId))
+
+  const specificationValues = await Promise.all(
+    specifications.map(({ FieldId }) => catalog.getSpecificationValues(FieldId))
+  )
+    .then(valuesBySpecification => unnest(valuesBySpecification))
+    .then(uniqBy(({ FieldValueId }) => FieldValueId))
+
+  const specificationsXLSX = specifications.map(specification =>
+    jsonToXLSXFields(specification, specificationToXLSXMap)
+  )
+  const valuesXLSX = specificationValues.map(value =>
+    jsonToXLSXFields(value, valueToXLSXMap)
+  )
+
+  return createXLSX({ 
+    Specifications: specificationsXLSX,
+    Values: valuesXLSX,
+  })
+}

--- a/node/resources/categorySpecs.ts
+++ b/node/resources/categorySpecs.ts
@@ -1,5 +1,5 @@
 import { uniqBy, unnest } from 'ramda'
-import { SpecificationTranslatables, SpecificationValueTranslatables } from '../typings/typings'
+import { Category, Specification, SpecificationTranslatables, SpecificationValueTranslatables } from '../typings/typings'
 import { createXLSX, jsonToXLSXFields } from './xlsx'
 
 const specificationToXLSXMap: Record<keyof SpecificationTranslatables, string> = {
@@ -12,16 +12,22 @@ const valueToXLSXMap: Record<keyof SpecificationValueTranslatables, string> = {
   Value: '_Value',
 }
 
-export async function getCategorySpecsXLXS(ctx: Context) {
-  const { clients: { catalog } } = ctx
-  const categories = await catalog.exportCategories()
-
-  const specifications = await Promise.all([
+export function getCategoriesSpecifications(
+  categories: Category[],
+  { clients: { catalog } }: Context
+): Promise<Specification[]> {
+  return Promise.all([
     catalog.getSpecificationsTreeByCategory(categories[0].id),
     ...categories.map(({ id }) => catalog.getSpecificationsByCategory(id)),
   ])
     .then(specificationsByCategory => unnest(specificationsByCategory))
     .then(uniqBy(({ FieldId }) => FieldId))
+}
+
+export async function getCategorySpecsXLXS(ctx: Context) {
+  const { clients: { catalog } } = ctx
+  const categories = await catalog.exportCategories()
+  const specifications = await getCategoriesSpecifications(categories, ctx)
 
   const specificationValues = await Promise.all(
     specifications.map(({ FieldId }) => catalog.getSpecificationValues(FieldId))

--- a/node/resources/productSpecs.ts
+++ b/node/resources/productSpecs.ts
@@ -1,7 +1,7 @@
 import { chain, uniq, unnest } from 'ramda'
 import { Catalog } from '../clients/catalog'
 import { Category, ProductSpecification, SpecificationFields } from '../typings/typings'
-import { getCategoriesSpecifications } from './categorySpecs'
+import { getSpecifications } from './categorySpecs'
 import { isProductSpecification, range } from './utils'
 import { createXLSX, jsonToXLSXFields } from './xlsx'
 
@@ -65,7 +65,7 @@ async function getCategoriesSpecificationsFieldsById(
   const {
     clients: { catalog },
   } = ctx
-  const specifications = await getCategoriesSpecifications(categories, ctx)
+  const specifications = await getSpecifications(categories, ctx)
   const specificationsFieldsById: Record<string, SpecificationFields> = {}
 
   await Promise.all(
@@ -79,7 +79,7 @@ async function getCategoriesSpecificationsFieldsById(
   return specificationsFieldsById
 }
 
-export async function getProductsSpecifications(ctx: Context) {
+export async function getTextSpecificationstValues(ctx: Context) {
   const { clients: { catalog } } = ctx
   const categories = await catalog.exportCategories()
 
@@ -105,6 +105,6 @@ export async function getProductsSpecifications(ctx: Context) {
   )
 
   return createXLSX({
-    'Product Specifications': specificationsXLSX,
+    'Text Specification Values': specificationsXLSX,
   })
 }

--- a/node/resources/productSpecs.ts
+++ b/node/resources/productSpecs.ts
@@ -1,0 +1,110 @@
+import { chain, uniq, unnest } from 'ramda'
+import { Catalog } from '../clients/catalog'
+import { Category, ProductSpecification, SpecificationFields } from '../typings/typings'
+import { getCategoriesSpecifications } from './categorySpecs'
+import { isProductSpecification, range } from './utils'
+import { createXLSX, jsonToXLSXFields } from './xlsx'
+
+// Limit of the API
+const BATCH_SIZE = 51
+
+const specificationToXLSXMap: Record<keyof ProductSpecification, string> = {
+  Id: '_SpecificationId',
+  Name: '_SpecificationName',
+  Value: '_SpecificationValue',
+  productId: '_ProductId',
+}
+
+async function getCategoryProducts({ id }: Category, catalog: Catalog): Promise<string[]> {
+  const {
+    range: { total },
+    data: firstData,
+  } = await catalog.getProductAndSkuByCategory(id, 1, BATCH_SIZE) 
+
+  const froms = range(BATCH_SIZE + 1, total, BATCH_SIZE)
+
+  const results = await Promise.all(
+    froms.map(from =>
+      catalog.getProductAndSkuByCategory(id, from, from + BATCH_SIZE - 1)
+    )
+  )
+
+  return [
+    ...Object.keys(firstData),
+    ...chain(({ data }) => Object.keys(data), results),
+  ]
+}
+
+async function getProductsSpecificationsFromCategories(
+  categories: Category[],
+  { clients: { catalog } }: Context
+): Promise<ProductSpecification[]> {
+  const products = await Promise.all(
+    categories.map(category => getCategoryProducts(category, catalog))
+  )
+    .then(productsByCategory => unnest(productsByCategory))
+    .then(repeatedProducts => uniq(repeatedProducts))
+
+  const specificationsByProduct = await Promise.all(
+    products.map(async productId => {
+      const specifications = await catalog.getProductSpecification(productId)
+      return specifications.map(specification => ({
+        ...specification,
+        productId: parseInt(productId, 10),
+      }))
+    })
+  )
+
+  return unnest(specificationsByProduct)
+}
+
+async function getCategoriesSpecificationsFieldsById(
+  categories: Category[],
+  ctx: Context
+): Promise<Record<string, SpecificationFields>> {
+  const {
+    clients: { catalog },
+  } = ctx
+  const specifications = await getCategoriesSpecifications(categories, ctx)
+  const specificationsFieldsById: Record<string, SpecificationFields> = {}
+
+  await Promise.all(
+    specifications.map(async ({ FieldId }) => {
+      specificationsFieldsById[FieldId] = await catalog.getSpecificationFields(
+        FieldId
+      )
+    })
+  )
+
+  return specificationsFieldsById
+}
+
+export async function getProductsSpecifications(ctx: Context) {
+  const { clients: { catalog } } = ctx
+  const categories = await catalog.exportCategories()
+
+  const [specifications, specificationFieldById] = await Promise.all([
+    getProductsSpecificationsFromCategories(categories, ctx),
+    getCategoriesSpecificationsFieldsById(categories, ctx),
+  ])
+
+  const productSpecifications = specifications.filter(({ Id }) =>
+    isProductSpecification(specificationFieldById[Id])
+  )
+
+  // Product specifications are supposed to have ONLY ONE item on the Value list
+  const normalizedSpecifications = productSpecifications.map(
+    ({ Value: [Value], ...specification }) => ({
+      ...specification,
+      Value,
+    })
+  )
+
+  const specificationsXLSX = normalizedSpecifications.map(specification =>
+    jsonToXLSXFields(specification, specificationToXLSXMap)
+  )
+
+  return createXLSX({
+    'Product Specifications': specificationsXLSX,
+  })
+}

--- a/node/resources/utils.ts
+++ b/node/resources/utils.ts
@@ -1,0 +1,27 @@
+import { SpecificationFields } from '../typings/typings'
+
+export function range(from: number, to: number, step: number = 1): number[] {
+  const values: number[] = []
+  for (let value = from; value <= to; value += step) {
+    values.concat(from)
+  }
+  return values
+}
+
+/*
+FieldTypeName by FieldTypeID:
+1 - Texto
+2 - Texto Grande
+4 - Número
+5 - Combo
+6 - Radio
+7 - CheckBox
+8 - Texto Indexado
+9 - Texto Grande Indexado
+
+Only "Texto", "Texto Grande", "Texto Indexado" and "Texto Grande Indexado" are translated on a product level.
+The other FieldTypes are stored as refereces and their values are stored as SpecificationField.
+*/
+export function isProductSpecification({ FieldTypeId }: SpecificationFields) {
+  return [1, 2, 8, 9].findIndex(id => FieldTypeId === id) !== -1
+}

--- a/node/resources/xlsx.ts
+++ b/node/resources/xlsx.ts
@@ -1,18 +1,22 @@
 import xlsx from 'xlsx'
 
-export function createXLSX(data: Array<unknown>, sheetName: string): Buffer {
-  const sheet = xlsx.utils.json_to_sheet(data)
+export function createXLSX(sheets: Record<string, Array<unknown>>): Buffer {
   const book = xlsx.utils.book_new()
-  xlsx.utils.book_append_sheet(book, sheet, sheetName)
+
+  Object.entries(sheets).forEach(([sheetName, data]) => {
+    const sheet = xlsx.utils.json_to_sheet(data)
+    xlsx.utils.book_append_sheet(book, sheet, sheetName)
+  })
 
   return xlsx.write(book, { type: 'buffer', bookType: 'xlsx' })
 }
 
-export function jsonToXLSXFields(data: Record<string, string>, jsonToXLSXField: Record<string, string>) {
-  const result: Record<string, string> = {}
-  const brandFieldAndValues = Object.entries(data)
-  brandFieldAndValues.forEach(
-    ([key, value]) => (result[jsonToXLSXField[key]] = value)
+export function jsonToXLSXFields(data: Record<string, unknown>, jsonToXLSXMap: Record<string, string>) {
+  return Object.entries(jsonToXLSXMap).reduce(
+    (result, [jsonKey, xlsxKey]) => {
+      result[xlsxKey] = data[jsonKey]
+      return result
+    },
+    {} as Record<string, unknown>
   )
-  return result
 }

--- a/node/service.json
+++ b/node/service.json
@@ -14,6 +14,11 @@
       "path": "/_v/private/vtex.admin-messages/v1/categories",
       "public": true,
       "smartcache": true
+    },
+    "categorySpecs": {
+      "path": "/_v/private/vtex.admin-messages/v1/category/specifications",
+      "public": true,
+      "smartcache": true
     }
   }
 }

--- a/node/service.json
+++ b/node/service.json
@@ -19,6 +19,11 @@
       "path": "/_v/private/vtex.admin-messages/v1/category/specifications",
       "public": true,
       "smartcache": true
+    },
+    "productSpecs": {
+      "path": "/_v/private/vtex.admin-messages/v1/product/specifications",
+      "public": true,
+      "smartcache": true
     }
   }
 }

--- a/node/service.json
+++ b/node/service.json
@@ -15,13 +15,13 @@
       "public": true,
       "smartcache": true
     },
-    "categorySpecs": {
-      "path": "/_v/private/vtex.admin-messages/v1/category/specifications",
+    "specifications": {
+      "path": "/_v/private/vtex.admin-messages/v1/specifications",
       "public": true,
       "smartcache": true
     },
-    "productSpecs": {
-      "path": "/_v/private/vtex.admin-messages/v1/product/specifications",
+    "specificationsTextValues": {
+      "path": "/_v/private/vtex.admin-messages/v1/specifications/text-values",
       "public": true,
       "smartcache": true
     }

--- a/node/typings/typings.d.ts
+++ b/node/typings/typings.d.ts
@@ -58,3 +58,51 @@ interface SpecificationValue extends SpecificationValueTranslatables {
   Position: number
   [key: string]: string
 }
+
+interface SpecificationValue extends SpecificationValueTranslatables {
+  IsActive: boolean
+  Position: number
+  [key: string]: string
+}
+
+interface SkusByProduct {
+  [productId: number]: [number]
+}
+
+interface ProductAndSkuByCategoryResult {
+  data: SkusByProduct
+  range: {
+    total: number
+    from: number
+    to: number
+  }
+}
+
+interface ProductSpecification {
+  productId: number | null
+  Value: string[]
+  Id: number
+  Name: string
+}
+
+interface SpecificationFields {
+  Name: string
+  CategoryId: number | null
+  FieldId: number
+  IsActive: boolean
+  IsRequired: boolean
+  FieldTypeId: number
+  FieldTypeName: string
+  FieldValueId: number | null
+  Description: string
+  IsStockKeepingUnit: boolean
+  IsFilter: boolean
+  IsOnProductDetails: boolean
+  Position: number
+  IsWizard: boolean
+  IsTopMenuLinkActive: boolean
+  IsSideMenuLinkActive: boolean
+  DefaultValue: string | number | null
+  FieldGroupId: number
+  FieldGroupName: string
+}

--- a/node/typings/typings.d.ts
+++ b/node/typings/typings.d.ts
@@ -7,3 +7,54 @@ interface FailedTranslation {
 }
 
 type Entity = 'product' | 'sku' | 'brand' | 'category' | 'specification' 
+
+interface CategoryTranslatables {
+  id: number
+  name: string
+  Title: string
+  MetaTagDescription: string
+}
+
+interface Category extends CategoryTranslatables {
+  hasChildren: boolean
+  url: string | null
+  children: Category[] | null
+  fathercategoryid: number
+  [key: string]: string
+}
+
+interface BrandTranslatables {
+  id: number
+  name: string
+  title: string
+  metaTagDescription: string
+}
+
+interface Brand extends BrandTranslatables {
+  isActive: boolean
+  imageUrl: string | null
+  [key: string]: string
+}
+
+interface SpecificationTranslatables {
+  Name: string
+  FieldId: number
+}
+
+interface Specification extends SpecificationTranslatables {
+  CategoryId: number
+  IsActive: boolean
+  IsStockKeepingUnit: boolean
+  [key: string]: string
+}
+
+interface SpecificationValueTranslatables {
+  FieldValueId: number
+  Value: string
+}
+
+interface SpecificationValue extends SpecificationValueTranslatables {
+  IsActive: boolean
+  Position: number
+  [key: string]: string
+}


### PR DESCRIPTION
Add handlers to allow exporting product and SKU specifications in a CSV-like file.

Actually, specifications are bound to categories.
But when the value is some type of free text, we cannot get the value from the category or specification. In this case, we have to go through the product to access the value.

To avoid a lot of columns with redundant translation on the exported file, I've separated text specification values from regular specifications field and values.


**This is horrible code and only works on Boticário**. 
It actually works on a lot of stores, but it can break if catalog grows. But we should not assume it and take this app as an silver bullet to solve any client's catalog translation problem.
Since we're trying to give a fast solutions, this one is good enough.